### PR TITLE
Trampoline calls to executor functions

### DIFF
--- a/src/simulator/executor.rs
+++ b/src/simulator/executor.rs
@@ -8,7 +8,11 @@ use crate::{
     simulator::{util::class_mask, EcallSignal},
 };
 
-type ExecutorFn = dyn Fn(&mut Simulator, &[Executor]);
+const PC_STOP_POS: usize = usize::MAX - 2;
+
+/// ExecutorFn executes an instruction and returns the new program counter.
+/// If the return value is PC_STOP_POS, the program is stopped
+type ExecutorFn = dyn Fn(&mut Simulator) -> usize;
 
 /// An Executor executes an instruction, moves the program counter forward (or appropriately, in
 /// the case of a jump), and continues execution by calling the next executor
@@ -16,12 +20,13 @@ type ExecutorFn = dyn Fn(&mut Simulator, &[Executor]);
 pub struct Executor(Box<ExecutorFn>);
 
 impl Executor {
-    pub fn new<F: Fn(&mut Simulator, &[Executor]) + 'static>(f: F) -> Self {
+    pub fn new<F: Fn(&mut Simulator) -> usize + 'static>(f: F) -> Self {
         Self(Box::new(f))
     }
 
-    pub fn call(&self, sim: &mut Simulator, next: &[Executor]) {
-        (self.0)(sim, next);
+    #[inline(always)]
+    pub fn call(&self, sim: &mut Simulator) -> usize {
+        (self.0)(sim)
     }
 }
 
@@ -45,29 +50,31 @@ fn display_memory_out_of_bounds_error(sim: &Simulator, position: usize) -> ! {
     std::process::exit(1);
 }
 
-fn display_instruction_out_of_bounds_error(sim: &Simulator, new_pc: usize) -> ! {
+fn display_instruction_out_of_bounds_error(sim: &Simulator) -> ! {
     eprintln!(
             "Tried to access instruction at pc {:x}, but code is only {:x} bytes long.\nLast instruction executed: {}",
-            new_pc,
+            sim.pc,
             sim.code.len() * 4,
-            sim.code_ctx[sim.pc >> 2],
+            sim.code_ctx[sim.pc >> 2], // BUG: this is wrong
         );
     std::process::exit(1);
 }
 
-/// Execute the next instruction
+/// Executes all instructions
 #[inline(always)]
-pub fn next(sim: &mut Simulator, code: &[Executor], new_pc: usize) {
-    if let Some(position) = sim.memory.out_of_bounds_access {
-        display_memory_out_of_bounds_error(sim, position);
+pub fn run(sim: &mut Simulator) {
+    let code = std::mem::take(&mut sim.code);
+    while sim.pc != PC_STOP_POS {
+        if let Some(position) = sim.memory.out_of_bounds_access {
+            display_memory_out_of_bounds_error(sim, position);
+        }
+
+        let executor = code
+            .get(sim.pc >> 2)
+            .unwrap_or_else(|| display_instruction_out_of_bounds_error(sim));
+
+        sim.pc = executor.call(sim);
     }
-
-    let executor = code
-        .get(new_pc >> 2)
-        .unwrap_or_else(|| display_instruction_out_of_bounds_error(sim, new_pc));
-
-    sim.pc = new_pc;
-    executor.call(sim, code);
 }
 
 fn from_bool(x: bool) -> u32 {
@@ -89,9 +96,9 @@ where
     R: IntoRegister,
     F: Fn(u32, u32) -> R + 'static,
 {
-    Executor::new(move |sim, code| {
+    Executor::new(move |sim| {
         sim.set_reg(rd, op(sim.reg(rs1), sim.reg(rs2)));
-        next(sim, code, sim.pc + 4);
+        sim.pc + 4
     })
 }
 
@@ -103,9 +110,9 @@ where
     R: IntoRegister,
     F: Fn(u32, u32) -> R + 'static,
 {
-    Executor::new(move |sim, code| {
+    Executor::new(move |sim| {
         sim.set_reg(rd, op(sim.reg(rs1), imm));
-        next(sim, code, sim.pc + 4);
+        sim.pc + 4
     })
 }
 
@@ -115,13 +122,12 @@ fn exec_branch<F>(rs1: u8, rs2: u8, label: usize, op: F) -> Executor
 where
     F: Fn(u32, u32) -> bool + 'static,
 {
-    Executor::new(move |sim, code| {
-        let new_pc = if op(sim.reg(rs1), sim.reg(rs2)) {
+    Executor::new(move |sim| {
+        if op(sim.reg(rs1), sim.reg(rs2)) {
             label
         } else {
             sim.pc + 4
-        };
-        next(sim, code, new_pc);
+        }
     })
 }
 
@@ -175,21 +181,21 @@ pub fn compile(i: &Instruction) -> Executor {
             }
         }),
         Remu(rd, rs1, rs2) => exec_type_r(rd, rs1, rs2, |a, b| if b == 0 { a } else { a % b }),
-        URet => Executor::new(move |sim, code| {
+        URet => Executor::new(move |sim| {
             use crate::parser::register_names::UEPC_INDEX;
-            next(sim, code, sim.status[UEPC_INDEX as usize] as usize);
+            sim.status[UEPC_INDEX as usize] as usize
         }),
 
         // Type I
-        Ecall => Executor::new(move |sim, code| {
+        Ecall => Executor::new(move |sim| {
             use EcallSignal::*;
             match sim.ecall() {
-                Exit => {} // don't execute the next instruction
-                Continue => next(sim, code, sim.pc),
-                Nothing => next(sim, code, sim.pc + 4),
+                Exit => PC_STOP_POS,
+                Continue => sim.pc,
+                Nothing => sim.pc + 4,
             }
         }),
-        Ebreak => Executor::new(move |sim, _code| {
+        Ebreak => Executor::new(move |sim| {
             let ctx = &sim.code_ctx[sim.pc / 4];
             eprintln!(
                 "   {} has not yet been implemented in FPGRARS!\n{}",
@@ -215,58 +221,58 @@ pub fn compile(i: &Instruction) -> Executor {
         }
 
         // Type I -- Loads
-        Lb(rd, imm, rs1) => Executor::new(move |sim, code| {
+        Lb(rd, imm, rs1) => Executor::new(move |sim| {
             let addr = sim.reg::<u32>(rs1).wrapping_add(imm) as usize;
             let data = sim.memory.get_byte(addr) as i8 as u32; // sign-extends
             sim.set_reg(rd, data);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Lbu(rd, imm, rs1) => Executor::new(move |sim, code| {
+        Lbu(rd, imm, rs1) => Executor::new(move |sim| {
             let addr = sim.reg::<u32>(rs1).wrapping_add(imm) as usize;
             let data = sim.memory.get_byte(addr) as u32;
             sim.set_reg(rd, data);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Lh(rd, imm, rs1) => Executor::new(move |sim, code| {
+        Lh(rd, imm, rs1) => Executor::new(move |sim| {
             let addr = sim.reg::<u32>(rs1).wrapping_add(imm) as usize;
             let data = sim.memory.get_half(addr) as i16 as u32; // sign-extends
             sim.set_reg(rd, data);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Lhu(rd, imm, rs1) => Executor::new(move |sim, code| {
+        Lhu(rd, imm, rs1) => Executor::new(move |sim| {
             let addr = sim.reg::<u32>(rs1).wrapping_add(imm) as usize;
             let data = sim.memory.get_half(addr) as u32;
             sim.set_reg(rd, data);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Lw(rd, imm, rs1) => Executor::new(move |sim, code| {
+        Lw(rd, imm, rs1) => Executor::new(move |sim| {
             let addr = sim.reg::<u32>(rs1).wrapping_add(imm) as usize;
             let data = sim.memory.get_word(addr);
             sim.set_reg(rd, data);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
 
         // Type S
-        Sb(rs2, imm, rs1) => Executor::new(move |sim, code| {
+        Sb(rs2, imm, rs1) => Executor::new(move |sim| {
             sim.memory.set_byte(
                 (sim.reg::<u32>(rs1).wrapping_add(imm)) as usize,
                 sim.reg::<u8>(rs2),
             );
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Sh(rs2, imm, rs1) => Executor::new(move |sim, code| {
+        Sh(rs2, imm, rs1) => Executor::new(move |sim| {
             sim.memory.set_half(
                 (sim.reg::<u32>(rs1).wrapping_add(imm)) as usize,
                 sim.reg::<u16>(rs2),
             );
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Sw(rs2, imm, rs1) => Executor::new(move |sim, code| {
+        Sw(rs2, imm, rs1) => Executor::new(move |sim| {
             sim.memory.set_word(
                 (sim.reg::<u32>(rs1).wrapping_add(imm)) as usize,
                 sim.reg::<u32>(rs2),
             );
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
 
         // Type B
@@ -278,64 +284,64 @@ pub fn compile(i: &Instruction) -> Executor {
         Bgeu(rs1, rs2, label) => exec_branch(rs1, rs2, label, |a, b| a >= b),
 
         // Jumps
-        Jalr(rd, rs1, imm) => Executor::new(move |sim, code| {
+        Jalr(rd, rs1, imm) => Executor::new(move |sim| {
             // This produces a weird result for `jalr s0 s0 0`. s0 is set to pc+4 before the jump occurs
             // so it works as a nop. Maybe this is correct, maybe it's not, but I'll copy the behavior seen in
             // RARS to be consistent.
             sim.set_reg(rd, (sim.pc + 4) as u32);
             let new_pc = (sim.reg::<i32>(rs1) + (imm as i32)) as usize & !1;
-            next(sim, code, new_pc);
+            new_pc
         }),
-        Jal(rd, label) => Executor::new(move |sim, code| {
+        Jal(rd, label) => Executor::new(move |sim| {
             sim.set_reg(rd, (sim.pc + 4) as u32);
-            next(sim, code, label);
+            label
         }),
 
         // CSR
-        CsrRw(rd, fcsr, rs1) => Executor::new(move |sim, code| {
+        CsrRw(rd, fcsr, rs1) => Executor::new(move |sim| {
             sim.set_reg(rd, sim.get_status(fcsr));
             sim.status[fcsr as usize] = sim.reg::<u32>(rs1);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        CsrRwi(rd, fcsr, imm) => Executor::new(move |sim, code| {
+        CsrRwi(rd, fcsr, imm) => Executor::new(move |sim| {
             sim.set_reg(rd, sim.get_status(fcsr));
             sim.status[fcsr as usize] = imm;
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        CsrRs(rd, fcsr, rs1) => Executor::new(move |sim, code| {
+        CsrRs(rd, fcsr, rs1) => Executor::new(move |sim| {
             sim.set_reg(rd, sim.get_status(fcsr));
             sim.status[fcsr as usize] |= sim.reg::<u32>(rs1);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        CsrRsi(rd, fcsr, imm) => Executor::new(move |sim, code| {
+        CsrRsi(rd, fcsr, imm) => Executor::new(move |sim| {
             sim.set_reg(rd, sim.get_status(fcsr));
             sim.status[fcsr as usize] |= imm;
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        CsrRc(rd, fcsr, rs1) => Executor::new(move |sim, code| {
+        CsrRc(rd, fcsr, rs1) => Executor::new(move |sim| {
             sim.set_reg(rd, sim.get_status(fcsr));
             sim.status[fcsr as usize] &= !sim.reg::<u32>(rs1);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        CsrRci(rd, fcsr, imm) => Executor::new(move |sim, code| {
+        CsrRci(rd, fcsr, imm) => Executor::new(move |sim| {
             sim.set_reg(rd, sim.get_status(fcsr));
             sim.status[fcsr as usize] &= !imm;
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
 
         // Type U
         Lui(rd, imm) => {
             let imm = imm << 12;
-            Executor::new(move |sim, code| {
+            Executor::new(move |sim| {
                 sim.set_reg(rd, imm);
-                next(sim, code, sim.pc + 4);
+                sim.pc + 4
             })
         }
         AuiPc(rd, imm) => {
             let imm = imm << 12;
-            Executor::new(move |sim, code| {
+            Executor::new(move |sim| {
                 sim.set_reg(rd, sim.pc as u32 + imm);
-                next(sim, code, sim.pc + 4);
+                sim.pc + 4
             })
         }
 
@@ -343,14 +349,14 @@ pub fn compile(i: &Instruction) -> Executor {
         Float(ref finstr) => compile_float_instruction(finstr),
 
         // Pseudoinstructions
-        Li(rd, imm) => Executor::new(move |sim, code| {
+        Li(rd, imm) => Executor::new(move |sim| {
             sim.set_reg(rd, imm as i32);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
 
-        Mv(rd, rs1) => Executor::new(move |sim, code| {
+        Mv(rd, rs1) => Executor::new(move |sim| {
             sim.set_reg(rd, sim.reg::<u32>(rs1));
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
     }
 }
@@ -360,62 +366,62 @@ pub fn compile_float_instruction(i: &FloatInstruction) -> Executor {
     use FloatInstruction::*;
 
     match *i {
-        Add(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Add(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             sim.floats[rd] = sim.floats[rs1] + sim.floats[rs2];
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Sub(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Sub(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             sim.floats[rd] = sim.floats[rs1] - sim.floats[rs2];
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Mul(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Mul(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             sim.floats[rd] = sim.floats[rs1] * sim.floats[rs2];
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Div(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Div(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             sim.floats[rd] = sim.floats[rs1] / sim.floats[rs2];
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Equ(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Equ(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rs1, rs2) = (rs1 as usize, rs2 as usize);
             sim.set_reg(rd, from_bool(sim.floats[rs1] == sim.floats[rs2]));
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Le(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Le(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rs1, rs2) = (rs1 as usize, rs2 as usize);
             sim.set_reg(rd, from_bool(sim.floats[rs1] <= sim.floats[rs2]));
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Lt(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Lt(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rs1, rs2) = (rs1 as usize, rs2 as usize);
             sim.set_reg(rd, from_bool(sim.floats[rs1] < sim.floats[rs2]));
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Max(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Max(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             sim.floats[rd] = sim.floats[rs1].max(sim.floats[rs2]);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Min(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        Min(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             sim.floats[rd] = sim.floats[rs1].min(sim.floats[rs2]);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        SgnjS(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        SgnjS(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             sim.floats[rd] = sim.floats[rs1].copysign(sim.floats[rs2]);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        SgnjNS(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        SgnjNS(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             sim.floats[rd] = sim.floats[rs1].copysign(-sim.floats[rs2]);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        SgnjXS(rd, rs1, rs2) => Executor::new(move |sim, code| {
+        SgnjXS(rd, rs1, rs2) => Executor::new(move |sim| {
             let (rd, rs1, rs2) = (rd as usize, rs1 as usize, rs2 as usize);
             let (a, b) = (sim.floats[rs1], sim.floats[rs2]);
 
@@ -423,64 +429,64 @@ pub fn compile_float_instruction(i: &FloatInstruction) -> Executor {
             // TODO: is it correct?
             sim.floats[rd] = f32::from_bits(a.to_bits() ^ (b.to_bits() & (1 << 31)));
 
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
 
         // I didn't even know this existed before this project
-        Class(rd, rs1) => Executor::new(move |sim, code| {
+        Class(rd, rs1) => Executor::new(move |sim| {
             let rs1 = rs1 as usize;
             sim.set_reg(rd, class_mask(sim.floats[rs1]));
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
 
-        CvtSW(rd, rs1) => Executor::new(move |sim, code| {
+        CvtSW(rd, rs1) => Executor::new(move |sim| {
             let rd = rd as usize;
             sim.floats[rd] = sim.reg::<i32>(rs1) as f32;
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        CvtSWu(rd, rs1) => Executor::new(move |sim, code| {
+        CvtSWu(rd, rs1) => Executor::new(move |sim| {
             let rd = rd as usize;
             sim.floats[rd] = sim.reg::<u32>(rs1) as f32;
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        CvtWS(rd, rs1) => Executor::new(move |sim, code| {
+        CvtWS(rd, rs1) => Executor::new(move |sim| {
             let rs1 = rs1 as usize;
             sim.set_reg(rd, sim.floats[rs1] as i32);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        CvtWuS(rd, rs1) => Executor::new(move |sim, code| {
+        CvtWuS(rd, rs1) => Executor::new(move |sim| {
             let rs1 = rs1 as usize;
             sim.set_reg(rd, sim.floats[rs1] as u32);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
 
-        MvSX(rd, rs1) => Executor::new(move |sim, code| {
+        MvSX(rd, rs1) => Executor::new(move |sim| {
             let rd = rd as usize;
             sim.floats[rd] = f32::from_bits(sim.reg::<u32>(rs1));
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        MvXS(rd, rs1) => Executor::new(move |sim, code| {
+        MvXS(rd, rs1) => Executor::new(move |sim| {
             let rs1 = rs1 as usize;
             sim.set_reg(rd, sim.floats[rs1].to_bits());
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Sqrt(rd, rs1) => Executor::new(move |sim, code| {
+        Sqrt(rd, rs1) => Executor::new(move |sim| {
             let (rd, rs1) = (rd as usize, rs1 as usize);
             sim.floats[rd] = sim.floats[rs1].sqrt();
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Lw(rd, imm, rs1) => Executor::new(move |sim, code| {
+        Lw(rd, imm, rs1) => Executor::new(move |sim| {
             let rd = rd as usize;
             let addr = sim.reg::<u32>(rs1).wrapping_add(imm) as usize;
             let data = sim.memory.get_float(addr);
             sim.floats[rd] = data;
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
-        Sw(rs2, imm, rs1) => Executor::new(move |sim, code| {
+        Sw(rs2, imm, rs1) => Executor::new(move |sim| {
             let x = sim.floats[rs2 as usize];
             let addr = sim.reg::<u32>(rs1).wrapping_add(imm) as usize;
             sim.memory.set_float(addr, x);
-            next(sim, code, sim.pc + 4);
+            sim.pc + 4
         }),
     }
 }

--- a/src/simulator/mod.rs
+++ b/src/simulator/mod.rs
@@ -18,7 +18,7 @@ use crate::renderer::{FRAME_0, FRAME_1, FRAME_SIZE};
 use into_register::*;
 use memory::*;
 use owo_colors::OwoColorize;
-use std::{mem, time};
+use std::time;
 
 /// Returned by the [ecall](struct.Simulator.html#method.ecall) procedure
 enum EcallSignal {
@@ -181,10 +181,7 @@ impl Simulator {
             return 0;
         }
 
-        // Copy code to local variable so we can access it without borrowing self
-        let code = mem::take(&mut self.code);
-
-        executor::next(self, &code, self.pc);
+        executor::run(self);
 
         if self.config.print_state {
             self.print_state();


### PR DESCRIPTION
This eliminates any recursion, that should fix the stack overflows we're having. It may negatively impact performance though, I'll have to test that.

![image](https://github.com/LeoRiether/FPGRARS/assets/8211902/0ef53565-35a2-4ae4-892a-f895a1d374ea)
May be slower than before...